### PR TITLE
Upgrade to dex2jar 2.0

### DIFF
--- a/lib/install_deps.sh
+++ b/lib/install_deps.sh
@@ -16,10 +16,6 @@ mkdir apktool
 mv apktool_2.0.0rc2.jar apktool/apktool.jar
 
 # download dex2jar
-# wget http://dex2jar.googlecode.com/files/dex2jar-0.0.9.15.zip
-# unzip dex2jar-0.0.9.15.zip
-# mv dex2jar-0.0.9.15 dex2jar
-# rm dex2jar-0.0.9.15.zip
 wget http://downloads.sourceforge.net/project/dex2jar/dex2jar-2.0-20140818.061505-10.zip
 unzip dex2jar-2.0-20140818.061505-10.zip
 mv dex2jar-2.0-SNAPSHOT dex2jar


### PR DESCRIPTION
Upgrade to avoid errors like this:

```
ncc@ncc:~$ ./d2j-dex2jar.sh ~/apks/android_4.4.2_r1/malware/mal_com.whatsapp.apk
dex2jar /home/ncc/apks/android_4.4.2_r1/malware/mal_com.whatsapp.apk -> mal_com.whatsapp-dex2jar.jar
com.googlecode.dex2jar.DexException: while accept method [Landroid/support/v4/app/FragmentTransaction;.add(ILandroid/support/v4/app/Fragment;Ljava/lang/String;)Landroid/support/v4/app/FragmentTransaction;]
    at com.googlecode.dex2jar.reader.DexFileReader.acceptMethod(DexFileReader.java:694)
    at com.googlecode.dex2jar.reader.DexFileReader.acceptClass(DexFileReader.java:441)
    at com.googlecode.dex2jar.reader.DexFileReader.accept(DexFileReader.java:323)
    at com.googlecode.dex2jar.v3.Dex2jar.doTranslate(Dex2jar.java:85)
    at com.googlecode.dex2jar.v3.Dex2jar.to(Dex2jar.java:261)
    at com.googlecode.dex2jar.v3.Dex2jar.to(Dex2jar.java:252)
    at com.googlecode.dex2jar.tools.Dex2jarCmd.doCommandLine(Dex2jarCmd.java:110)
    at com.googlecode.dex2jar.tools.BaseCmd.doMain(BaseCmd.java:174)
    at com.googlecode.dex2jar.tools.Dex2jarCmd.main(Dex2jarCmd.java:34)
Caused by: com.googlecode.dex2jar.DexException: while accept parameter annotation in method:[Landroid/support/v4/app/FragmentTransaction;.add(ILandroid/support/v4/app/Fragment;Ljava/lang/String;)Landroid/support/v4/app/FragmentTransaction;], parameter:[0]
    at com.googlecode.dex2jar.reader.DexFileReader.acceptMethod(DexFileReader.java:663)
    ... 8 more
Caused by: com.googlecode.dex2jar.DexException: Not support yet.
    at com.googlecode.dex2jar.reader.Constant.ReadConstant(Constant.java:128)
    at com.googlecode.dex2jar.reader.DexAnnotationReader.accept(DexAnnotationReader.java:58)
    at com.googlecode.dex2jar.reader.DexFileReader.acceptMethod(DexFileReader.java:660)
    ... 8 more
```

Dex2jar's new site is here https://sourceforge.net/projects/dex2jar/
