### PR TITLE
Added more exclusions for no fragment flag

### DIFF
--- a/src/main/scala/edu/colorado/droidel/codegen/SimpleAndroidHarnessGenerator.scala
+++ b/src/main/scala/edu/colorado/droidel/codegen/SimpleAndroidHarnessGenerator.scala
@@ -8,7 +8,7 @@ import edu.colorado.droidel.constants.AndroidConstants._
 import edu.colorado.droidel.constants.DroidelConstants._
 
 /** generate a harness that calls the Android main (ActivityThread.main) and injects our stubs */
-class SimpleAndroidHarnessGenerator extends AndroidStubGenerator {
+class SimpleAndroidHarnessGenerator(generateFragmentStubs: Boolean) extends AndroidStubGenerator {
 
   def generateHarness(instrumentedBinDir : String, androidJarPath : String, generateFragmentStubs : Boolean) : Unit = {
     writer.emitPackage(HARNESS_DIR)
@@ -49,8 +49,10 @@ class SimpleAndroidHarnessGenerator extends AndroidStubGenerator {
     }
 
     emitInflateLayoutComponentById(VIEW_TYPE, INFLATE_VIEW_BY_ID)
-    emitGetFragment(FRAGMENT_TYPE, GET_SUPPORT_FRAGMENT)
-    emitGetFragment(APP_FRAGMENT_TYPE, GET_APP_FRAGMENT)
+    if(generateFragmentStubs) {
+      emitGetFragment(FRAGMENT_TYPE, GET_SUPPORT_FRAGMENT)
+      emitGetFragment(APP_FRAGMENT_TYPE, GET_APP_FRAGMENT)
+    }
 
     // emit override method for manifest-declared callbacks
     writer.emitAnnotation(OVERRIDE)

--- a/src/main/scala/edu/colorado/droidel/driver/AndroidAppTransformer.scala
+++ b/src/main/scala/edu/colorado/droidel/driver/AndroidAppTransformer.scala
@@ -617,7 +617,7 @@ class AndroidAppTransformer(_appPath : String, androidJar : File, droidelHome : 
     Process(Seq("mv", STUB_DIR, s"$instrumentedBinDirPath${File.separator}${STUB_DIR}")).!!
 
     // note that this automatically moves the compiled harness file into the bin directory for the instrumented app
-    val harnessGen = new SimpleAndroidHarnessGenerator()
+    val harnessGen = new SimpleAndroidHarnessGenerator(generateFragmentStubs)
     harnessGen.generateHarness(instrumentedBinDirPath, androidJar.getAbsolutePath, generateFragmentStubs)
     instrumentedBinDirFile
   }


### PR DESCRIPTION
SimpleAndroidHarnessGenerator had a couple places where fragment stubs were still being generated while the -no_fragment_stubs flag was enabled.  This should fix it.
